### PR TITLE
Homepage revamp: positioning, honest team, WhatsApp-first contact

### DIFF
--- a/app/components/ContactSection.jsx
+++ b/app/components/ContactSection.jsx
@@ -2,182 +2,133 @@
 
 import Image from "next/image";
 import Separator from "@/public/Separator.png";
-import Divy from "@/public/Divy.jpg";
-import React, { useState, useRef } from "react";
-import { cn } from "@/lib/utils";
-import { Label } from "@/components/ui/label";
-import { Input } from "@/components/ui/input";
-import { Send } from "lucide-react";
-import emailjs from '@emailjs/browser';
+import React, { useState } from "react";
+import emailjs from "@emailjs/browser";
 
-
+// WhatsApp is the primary communication channel.
+const WHATSAPP_NUMBER = "918954000202";
+const PHONE_DISPLAY = "+91 89540 00202";
 
 export default function ContactSection() {
-    const [userName, setUserName] = useState('')
-    const [userMail, setUserMail] = useState('')
-    const [loading, setLoading] = useState(false)
+    const [name, setName] = useState("");
+    const [whatsapp, setWhatsapp] = useState("");
+    const [sending, setSending] = useState(false);
 
-    const form = useRef(null);
-    const sendEmail = (e) => {
+    const valid = name.trim() !== "" && whatsapp.trim() !== "";
+
+    const handleSubmit = (e) => {
         e.preventDefault();
-        if (!form.current) return;
-        setLoading(true);
+        if (!valid || sending) return;
+        setSending(true);
 
+        // Capture the lead in the background (same EmailJS template as before)
         emailjs
-            .sendForm(
-                'service_db4zwz8',      // ← replace
-                'template_oiu2ped',     // ← replace
-                form.current,
-                'oo80cgXuN0GQTNqFm'       // ← replacecd sof
-            )
-            .then(
-                () => {
-                    setLoading(false);
-                    alert('Thanks! We’ll be in touch soon.');
-                    // optional: reset form
-                    form.current?.reset();
-                    setUserName('');
-                    setUserMail('');
+            .send(
+                "service_db4zwz8",
+                "template_oiu2ped",
+                {
+                    user_name: name,
+                    user_phone: whatsapp,
+                    user_email: "",
+                    user_message: `WhatsApp lead from softles.in homepage\nName: ${name}\nWhatsApp: ${whatsapp}`,
                 },
-                (err) => {
-                    console.error(err);
-                    setLoading(false);
-                    alert('Sorry, something went wrong. Try again.');
-                }
-            );
+                "oo80cgXuN0GQTNqFm"
+            )
+            .catch((err) => console.error(err));
+
+        // Open WhatsApp with a prefilled message — primary action, don't wait on email
+        const text = `Hi SoftLes, I'm ${name}. I'd like to talk about my project.`;
+        window.open(
+            `https://wa.me/${WHATSAPP_NUMBER}?text=${encodeURIComponent(text)}`,
+            "_blank",
+            "noopener,noreferrer"
+        );
+        setSending(false);
     };
 
-    const isFormValid = () => {
-        return (
-            userName.trim() !== '' &&
-            userMail.trim() !== ''
-        )
-    }
     return (
         <section id="book-call" className="w-full py-12 md:py-20 px-0 flex flex-col justify-center place-content-between bg-[#12131c] border-t border-b border-[#2a2e40]">
-            <div className="service-page-container mx-auto w-full flex flex-col gap-12">
+            <div className="service-page-container mx-auto w-full flex flex-col">
+                {/* Header */}
                 <div className="flex flex-col">
                     <div className="flex items-center text-base font-normal text-[#FFFFFF]">
                         <Image src={Separator} alt="separator" width={0} height={0} sizes="(max-width: 768px) 20vw, (max-width: 1024px) 10vw, 6vw" className="object-cover overflow-hidden h-[2px] w-auto mr-[10px]" />
                         <p className="text-sm uppercase tracking-[0.2em] text-[#BCC1CA]">
-                            Get In Touch
+                            Get in touch
                         </p>
                     </div>
-                    <span className="mt-2 mb-4 lg:mb-0 service-section-heading text-[#FFFFFF]">Book a Discovery Session</span>
+                    <span className="mt-2 mb-2 lg:mb-0 service-section-heading text-[#FFFFFF]">Let&apos;s talk on WhatsApp</span>
+                    <span className="text-sm sm:text-base text-[#BCC1CA]/80 mt-2 max-w-2xl leading-relaxed">
+                        Tell us who you are and we&apos;ll continue on WhatsApp — the fastest way to
+                        reach us. No long forms, no waiting for callbacks.
+                    </span>
                 </div>
-                <div className="w-full flex flex-col md:flex-row gap-0 mt-12 justify-center items-stretch">
-                    {/* Book a Discovery Session via Google Meet */}
-                <div className="bg-gradient-to-br from-[#191C26] via-[#221429] to-[#191C26] rounded-2xl md:rounded-r-none md:rounded-l-2xl mb-5 md:mb-0 shadow-lg flex flex-col justify-between p-0 border border-[#23263a] w-full md:w-1/3 max-w-none">
-                    <div className="flex flex-col items-center pt-8 pb-4 px-3 md:px-6 h-full">
-                        <div className="relative">
-                            <Image src={Divy} alt="Expert Image" className="rounded-xl w-[180px] h-[180px] object-cover border-4 border-[#221429] shadow-md" />
-                        </div>
-                        <div className="mt-4 bg-[#221429] rounded-xl px-5 py-2 shadow-lg flex flex-col items-center">
-                            <p className="text-lg font-semibold text-white">Divyansh Veermanya</p>
-                            <p className="text-sm font-normal text-[#bdbdbd]">Product Lead</p>
-                        </div>
-                        <div className="bg-[#221429] px-8 py-6 flex flex-col items-center gap-3 border-t border-[#23263a] w-full mt-8 rounded-b-2xl">
-                            <h2 className="font-bold text-2xl text-white text-center">Book a Discovery Session</h2>
-                            <p className="text-base font-medium text-[#bdbdbd] text-center">
-                                Instantly schedule a call with our expert.<br />
-                                <span className="text-xs text-[#888]">Powered by <span className="font-semibold">Google Meet</span></span>
-                            </p>
-                            <a
-                                href="https://calendar.google.com/calendar/u/0?cid=ZGl2eWFuc2gudmVlcm1hbnlhQGdtYWlsLmNvbQ" // ← put your own public booking URL here
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className="mt-4 py-2 px-8 rounded-full border border-[#DC4242] text-[#DC4242] text-base font-semibold hover:bg-[#DC4242] hover:text-white transition-colors duration-200 shadow-sm text-center"
-                            >
-                                Book via Google Meet
-                            </a>
-                            <span className="text-xs text-[#bdbdbd] mt-2">Email: <a href="mailto:info@softles.in?cc=hr@softles.in" className="underline hover:text-[#DC4242] transition">info@softles.in</a>, <a href="mailto:hr@softles.com?cc=info@softles.in" className="underline hover:text-[#DC4242] transition">hr@softles.in</a></span>
-                        </div>
-                    </div>
-                </div>
-                {/* Submit details for callback */}
-                <div className="bg-gradient-to-br from-[#191C26] via-[#23263a] to-[#191C26] rounded-2xl md:rounded-l-none rounded-r-2xl shadow-lg flex flex-col justify-center p-3 md:p-8 border-t border-b border-r border-[#23263a] w-full md:w-2/3 max-w-none">
-                    <form className="w-full" ref={form} onSubmit={sendEmail} autoComplete="off">
-                        <h3 className="text-2xl font-bold text-white mb-6 text-center">Let us reach out to you</h3>
-                        <LabelInputContainer className="mb-5">
-                            <Label htmlFor="name" className="text-[#bdbdbd]">Name <span className="text-[#DC4242]">*</span></Label>
-                            <Input id="name" name="user_name" placeholder="John Doe" type="text"
-                                value={userName}
-                                onChange={(e) => setUserName(e.target.value)}
-                                className="bg-[#181a20] border border-[#23263a] focus:border-[#DC4242] text-white placeholder-[#666] rounded-lg"
-                                required
-                            />
-                        </LabelInputContainer>
-                        <LabelInputContainer className="mb-5">
-                            <Label htmlFor="email" className="text-[#bdbdbd]">Email Address <span className="text-[#DC4242]">*</span></Label>
-                            <Input id="email" name="user_email" placeholder="johndoe@gmail.com" type="email"
-                                value={userMail}
-                                onChange={(e) => setUserMail(e.target.value)}
-                                className="bg-[#181a20] border border-[#23263a] focus:border-[#DC4242] text-white placeholder-[#666] rounded-lg"
-                                required
-                            />
-                        </LabelInputContainer>
-                        <LabelInputContainer className="mb-5">
-                            <Label htmlFor="phone" className="text-[#bdbdbd]">Phone Number</Label>
-                            <Input id="phone" name="user_phone" placeholder="+91 98765 43210" type="tel"
-                                className="bg-[#181a20] border border-[#23263a] focus:border-[#DC4242] text-white placeholder-[#666] rounded-lg"
-                            />
-                        </LabelInputContainer>
-                        <LabelInputContainer className="mb-5">
-                            <Label htmlFor="message" className="text-[#bdbdbd]">Message (Optional)</Label>
-                            <textarea
-                                id="message"
-                                name="user_message"
-                                placeholder="Tell us about your needs..."
-                                rows={3}
-                                className="bg-[#181a20] border border-[#23263a] focus:border-[#DC4242] text-white placeholder-[#666] rounded-lg px-3 py-2 resize-none"
-                            />
-                        </LabelInputContainer>
+
+                {/* WhatsApp-first contact */}
+                <div className="mt-10 grid grid-cols-1 lg:grid-cols-2 gap-6 lg:gap-10 items-stretch">
+                    {/* Form → WhatsApp */}
+                    <form onSubmit={handleSubmit} className="bg-gradient-to-br from-[#23263a] to-[#181B23] rounded-2xl border border-[#2a2e40] p-6 sm:p-8 flex flex-col gap-4" autoComplete="off">
+                        <h3 className="text-xl font-bold text-white">Start the conversation</h3>
+                        <input
+                            type="text"
+                            placeholder="Your name *"
+                            value={name}
+                            onChange={(e) => setName(e.target.value)}
+                            required
+                            className="bg-[#181a20] border border-[#23263a] focus:border-[#DC4242] focus:outline-none text-white placeholder-[#777] rounded-lg px-4 py-3 text-sm"
+                        />
+                        <input
+                            type="tel"
+                            placeholder="Your WhatsApp number *"
+                            value={whatsapp}
+                            onChange={(e) => setWhatsapp(e.target.value)}
+                            required
+                            className="bg-[#181a20] border border-[#23263a] focus:border-[#DC4242] focus:outline-none text-white placeholder-[#777] rounded-lg px-4 py-3 text-sm"
+                        />
                         <button
-                            className={cn(
-                                "relative group/btn mt-8 w-full py-3 rounded-full font-semibold text-lg flex items-center justify-center gap-2 transition-all duration-200",
-                                "bg-gradient-to-br from-[#DC4242] to-[#b92d2d] border border-[#DC4242] text-white shadow-lg hover:from-[#b92d2d] hover:to-[#DC4242] hover:scale-[1.03]",
-                                loading ? "opacity-60 cursor-not-allowed" : ""
-                            )}
-                            value='send'
-                            disabled={!isFormValid() || loading}
                             type="submit"
+                            disabled={!valid || sending}
+                            className="mt-2 w-full py-3.5 rounded-full font-semibold text-base flex items-center justify-center gap-2 transition-all duration-200 bg-gradient-to-br from-[#25D366] to-[#128C7E] text-white shadow-lg hover:opacity-90 hover:scale-[1.02] disabled:opacity-50 disabled:cursor-not-allowed"
                         >
-                            {loading ? (
-                                <span className="animate-pulse">Sending ...</span>
-                            ) : (
-                                <>
-                                    <Send size={20} strokeWidth={2} />
-                                    Submit Details
-                                </>
-                            )}
+                            <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" className="shrink-0">
+                                <path d="M.057 24l1.687-6.163a11.867 11.867 0 01-1.587-5.946C.16 5.335 5.495 0 12.05 0a11.817 11.817 0 018.413 3.488 11.824 11.824 0 013.48 8.414c-.003 6.557-5.338 11.892-11.893 11.892a11.9 11.9 0 01-5.688-1.448L.057 24zm6.597-3.807c1.676.995 3.276 1.591 5.392 1.592 5.448 0 9.886-4.434 9.889-9.885.002-5.462-4.415-9.89-9.881-9.892-5.452 0-9.887 4.434-9.889 9.884a9.86 9.86 0 001.51 5.26l-.999 3.648 3.978-1.043z" />
+                            </svg>
+                            {sending ? "Opening WhatsApp…" : "Chat with us on WhatsApp"}
                         </button>
-                        <p className="text-xs text-[#bdbdbd] mt-4 text-center">
-                            We&apos;ll reach out to you to schedule your session.
+                        <p className="text-[#BCC1CA]/50 text-xs text-center">
+                            Opens WhatsApp with a prefilled message — send it and we&apos;ll reply within hours.
                         </p>
                     </form>
+
+                    {/* Direct contact */}
+                    <div className="bg-gradient-to-br from-[#191C26] to-[#181B23] rounded-2xl border border-[#2a2e40] p-6 sm:p-8 flex flex-col justify-center gap-5">
+                        <h3 className="text-xl font-bold text-white">Prefer to reach out directly?</h3>
+                        <div className="flex flex-col gap-3 text-[#BCC1CA]">
+                            <a href={`https://wa.me/${WHATSAPP_NUMBER}`} target="_blank" rel="noopener noreferrer" className="flex items-center gap-3 hover:text-[#25D366] transition-colors">
+                                <span className="w-9 h-9 rounded-lg bg-[#25D366]/10 border border-[#25D366]/30 flex items-center justify-center text-[#25D366]">
+                                    <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M.057 24l1.687-6.163a11.867 11.867 0 01-1.587-5.946C.16 5.335 5.495 0 12.05 0a11.817 11.817 0 018.413 3.488 11.824 11.824 0 013.48 8.414c-.003 6.557-5.338 11.892-11.893 11.892a11.9 11.9 0 01-5.688-1.448L.057 24z" /></svg>
+                                </span>
+                                WhatsApp: {PHONE_DISPLAY}
+                            </a>
+                            <a href="tel:+918954000202" className="flex items-center gap-3 hover:text-[#DC4242] transition-colors">
+                                <span className="w-9 h-9 rounded-lg bg-[#DC4242]/10 border border-[#DC4242]/30 flex items-center justify-center text-[#DC4242]">
+                                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M22 16.92v3a2 2 0 01-2.18 2 19.79 19.79 0 01-8.63-3.07 19.5 19.5 0 01-6-6 19.79 19.79 0 01-3.07-8.67A2 2 0 014.11 2h3a2 2 0 012 1.72c.127.96.361 1.903.7 2.81a2 2 0 01-.45 2.11L8.09 9.91a16 16 0 006 6l1.27-1.27a2 2 0 012.11-.45c.907.339 1.85.573 2.81.7A2 2 0 0122 16.92z" /></svg>
+                                </span>
+                                Call: {PHONE_DISPLAY}
+                            </a>
+                            <a href="mailto:info@softles.in" className="flex items-center gap-3 hover:text-[#DC4242] transition-colors">
+                                <span className="w-9 h-9 rounded-lg bg-[#DC4242]/10 border border-[#DC4242]/30 flex items-center justify-center text-[#DC4242]">
+                                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z" /><polyline points="22,6 12,13 2,6" /></svg>
+                                </span>
+                                info@softles.in
+                            </a>
+                        </div>
+                        <p className="text-[#BCC1CA]/50 text-xs">
+                            WhatsApp is our primary channel — it&apos;s where you&apos;ll get the fastest response.
+                        </p>
+                    </div>
                 </div>
             </div>
-            </div>
         </section>
-    )
+    );
 }
-
-const BottomGradient = () => {
-    return (
-        <>
-            <span className="group-hover/btn:opacity-100 block transition duration-500 opacity-0 absolute h-px w-full -bottom-px inset-x-0 bg-gradient-to-r from-transparent via-cyan-500 to-transparent" />
-            <span className="group-hover/btn:opacity-100 blur-sm block transition duration-500 opacity-0 absolute h-px w-1/2 mx-auto -bottom-px inset-x-10 bg-gradient-to-r from-transparent via-indigo-500 to-transparent" />
-        </>
-    );
-};
-
-const LabelInputContainer = ({
-    children,
-    className,
-}) => {
-    return (
-        <div className={cn("flex flex-col space-y-2 w-full", className)}>
-            {children}
-        </div>
-    );
-};

--- a/app/components/FeaturedCaseStudy.jsx
+++ b/app/components/FeaturedCaseStudy.jsx
@@ -1,0 +1,77 @@
+import Image from "next/image";
+import Link from "next/link";
+
+// Single featured case study under the hero — one strong story beats a wall of thumbnails.
+const STATS = [
+  { value: "2.5k+", label: "Orders" },
+  { value: "5/5", label: "Rating" },
+  { value: "30%", label: "Repeat rate" },
+];
+
+export default function FeaturedCaseStudy() {
+  return (
+    <section className="w-full py-12 md:py-20 bg-[#12131c] border-y border-[#2a2e40]">
+      <div className="service-page-container">
+        <div className="softles-eyebrow mb-3">
+          <span className="softles-eyebrow-line" />
+          <span className="softles-eyebrow-text">Featured work</span>
+        </div>
+
+        <div className="softles-card overflow-hidden grid grid-cols-1 lg:grid-cols-2">
+          {/* Store visual */}
+          <div className="relative min-h-[260px] lg:min-h-[380px] bg-[#0f111a]">
+            <Image
+              src="/brunswickfurfood.png"
+              alt="Brunswick Fur Food Shopify storefront"
+              fill
+              sizes="(max-width: 1024px) 100vw, 50vw"
+              className="object-cover object-top"
+            />
+            <div className="absolute inset-0 bg-gradient-to-t from-[#181B23] via-transparent to-transparent lg:bg-gradient-to-r" />
+          </div>
+
+          {/* Story */}
+          <div className="flex flex-col justify-center p-6 sm:p-10">
+            <span className="text-xs uppercase tracking-[0.2em] text-[#DC4242] font-bold mb-3">
+              Case study · Pet food, D2C
+            </span>
+            <h2 className="text-2xl md:text-3xl font-bold text-white leading-tight">
+              Brunswick Fur Food — fresh dog food, built to convert
+            </h2>
+            <p className="text-[#BCC1CA]/80 text-sm md:text-base leading-relaxed mt-4">
+              A Shopify experience that turns product quality into clear trust —
+              premium storefront, smoother subscriptions, and mobile-first UX for
+              a growing Melbourne brand.
+            </p>
+
+            <div className="grid grid-cols-3 gap-4 mt-7">
+              {STATS.map((s) => (
+                <div key={s.label} className="rounded-xl border border-[#2a2e40] bg-[#181B23] px-3 py-4 text-center">
+                  <div className="text-xl md:text-2xl font-black text-white">{s.value}</div>
+                  <div className="text-[11px] uppercase tracking-wider text-[#BCC1CA]/70 mt-1">{s.label}</div>
+                </div>
+              ))}
+            </div>
+
+            <div className="flex flex-wrap items-center gap-4 mt-8">
+              <a
+                href="https://www.brunswickfurfood.com/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="softles-primary-button !px-6 !py-3 text-sm"
+              >
+                Visit live store
+              </a>
+              <Link
+                href="/shopify-development"
+                className="text-sm font-bold text-[#DC4242] hover:underline"
+              >
+                See how we build Shopify stores →
+              </Link>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/app/components/Footer.jsx
+++ b/app/components/Footer.jsx
@@ -2,86 +2,76 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import { useState } from "react";
 
 export default function Footer() {
-    const [email, setEmail] = useState("");
-    const [submitted, setSubmitted] = useState(false);
-
-    const handleSubmit = (e) => {
-        e.preventDefault();
-        setSubmitted(true);
-        setEmail("");
-        setTimeout(() => setSubmitted(false), 3000);
-    };
-
     return (
         <footer className="snap-start bg-[#18181B] text-white pt-5 sm:pt-12 pb-6 px-5 md:px-16">
             <div className="flex flex-col gap-5 w-full service-page-container border-b border-[#27272A] pb-10">
                 <Link href="/">
                     <Image src={"/SoftLes.png"} alt="Logo" width={0} height={0} sizes="(max-width: 768px) 40vw, (max-width: 1024px) 50vw, 33vw" className="object-cover overflow-hidden min-w-min h-[54px] w-auto"/>
                 </Link>
-                <div className=" grid grid-cols-1 md:grid-cols-3 gap-10">
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-6 gap-10">
                     {/* About */}
-                    <div className="flex flex-col gap-y-3 w-full">
+                    <div className="flex flex-col gap-y-3 w-full lg:col-span-2">
                         <h3 className="font-semibold text-base mb-1">About</h3>
                         <p className="text-sm text-[#D4D4D8]">
                             At Softles, we craft unique digital experiences by combining design, technology, and strategy. From innovative UI/UX to smart development and automation, our passionate team helps businesses grow online. Book a free discovery call and let’s build something remarkable together. Your vision, our creativity — powered by purpose.
                         </p>
                     </div>
-                    <div className="flex flex-col gap-y-3 w-full">
-                        <h3 className="font-semibold text-base mb-1">Contact</h3>
-                        <div className="grid grid-cols-2 gap-5 w-full">
-                            <div className="flex flex-col gap-x-2">
-                                <h6 className="text-sm text-[#D4D4D8]">Email:</h6>
-                                <div className="flex flex-col items-start">
-                                    <a href="mailto:info@softles.com?cc=hr@softles.in" className="text-md font-medium underline hover:text-[#DC4242] transition">
-                                        info@softles.in
-                                    </a>
-                                    <a href="mailto:hr@softles.in?cc=info@softles.in" className="text-md font-medium underline hover:text-[#DC4242] transition">
-                                        hr@softles.in
-                                    </a>
-                                </div>
-                            </div>
-                            <div className="flex flex-col gap-x-2">
-                                <h6 className="text-sm text-[#D4D4D8]">Phone:</h6>
-                                <div className="flex flex-col items-start">
-                                    <a href="tel:+918954000202" className="text-md font-medium underline hover:text-[#DC4242] transition">
-                                        +918954000202
-                                    </a>
-                                    <a href="tel:+919990548795" className="text-md font-medium underline hover:text-[#DC4242] transition">
-                                        +919990548795
-                                    </a>
-                                </div>
-                            </div>
-                        </div>
+
+                    {/* WordPress services */}
+                    <div className="flex flex-col gap-y-2">
+                        <h3 className="font-semibold text-base mb-1">
+                            <Link href="/wordpress-development" className="hover:text-[#DC4242] transition">WordPress</Link>
+                        </h3>
+                        <ul className="space-y-2 text-sm text-[#D4D4D8]">
+                            <li><Link href="/wordpress-development" className="hover:text-[#DC4242] transition">Custom Theme Development</Link></li>
+                            <li><Link href="/wordpress-development" className="hover:text-[#DC4242] transition">Headless WordPress</Link></li>
+                            <li><Link href="/wordpress-development" className="hover:text-[#DC4242] transition">Plugins &amp; WooCommerce</Link></li>
+                            <li><Link href="/wordpress-development" className="hover:text-[#DC4242] transition">Integrations &amp; Automation</Link></li>
+                        </ul>
                     </div>
-                    {/* Newsletter */}
-                    <div>
-                        <h3 className="font-semibold text-base mb-3">Newsletter</h3>
-                        <p className="text-sm text-[#D4D4D8] mb-3">Stay up to date with our latest news and offers.</p>
-                        <form onSubmit={handleSubmit} className="flex flex-col gap-2">
-                            <label htmlFor="footer-email" className="sr-only">Email address</label>
-                            <input
-                                id="footer-email"
-                                type="email"
-                                name="email"
-                                value={email}
-                                onChange={e => setEmail(e.target.value)}
-                                placeholder="Your email address"
-                                className="bg-[#23232A] border border-[#27272A] rounded px-3 py-2 text-white placeholder-[#A1A1AA] focus:outline-none focus:border-[#DC4242] transition"
-                                required
-                            />
-                            <button
-                                type="submit"
-                                className="bg-[#DC4242] hover:bg-[#b32e2e] transition text-white rounded px-4 py-2 font-semibold"
-                            >
-                                Subscribe
-                            </button>
-                            {submitted && (
-                                <span className="text-green-400 text-xs mt-1">Thank you for subscribing!</span>
-                            )}
-                        </form>
+
+                    {/* Shopify services */}
+                    <div className="flex flex-col gap-y-2">
+                        <h3 className="font-semibold text-base mb-1">
+                            <Link href="/shopify-development" className="hover:text-[#DC4242] transition">Shopify</Link>
+                        </h3>
+                        <ul className="space-y-2 text-sm text-[#D4D4D8]">
+                            <li><Link href="/shopify-development" className="hover:text-[#DC4242] transition">Custom Theme Development</Link></li>
+                            <li><Link href="/shopify-development" className="hover:text-[#DC4242] transition">Headless &amp; Hydrogen</Link></li>
+                            <li><Link href="/shopify-development" className="hover:text-[#DC4242] transition">Shopify Apps</Link></li>
+                            <li><Link href="/shopify-development" className="hover:text-[#DC4242] transition">Integrations &amp; Automation</Link></li>
+                        </ul>
+                    </div>
+
+                    {/* Resources */}
+                    <div className="flex flex-col gap-y-2">
+                        <h3 className="font-semibold text-base mb-1">Resources</h3>
+                        <ul className="space-y-2 text-sm text-[#D4D4D8]">
+                            <li><Link href="/blog" className="hover:text-[#DC4242] transition">Blog</Link></li>
+                            <li><Link href="/blog" className="hover:text-[#DC4242] transition">Shopify &amp; WordPress guides</Link></li>
+                            <li><Link href="/#book-call" className="hover:text-[#DC4242] transition">Talk to us</Link></li>
+                        </ul>
+                    </div>
+
+                    {/* Contact */}
+                    <div className="flex flex-col gap-y-2">
+                        <h3 className="font-semibold text-base mb-1">Contact</h3>
+                        <div className="flex flex-col items-start gap-2 text-sm">
+                            <a href="mailto:info@softles.in?cc=hr@softles.in" className="font-medium underline hover:text-[#DC4242] transition">
+                                info@softles.in
+                            </a>
+                            <a href="mailto:hr@softles.in?cc=info@softles.in" className="font-medium underline hover:text-[#DC4242] transition">
+                                hr@softles.in
+                            </a>
+                            <a href="tel:+918954000202" className="font-medium underline hover:text-[#DC4242] transition">
+                                +91 89540 00202
+                            </a>
+                            <a href="tel:+919990548795" className="font-medium underline hover:text-[#DC4242] transition">
+                                +91 99905 48795
+                            </a>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/app/components/Hero.jsx
+++ b/app/components/Hero.jsx
@@ -71,36 +71,32 @@ export default function Hero() {
                             <span className="text-base text-[#BCC1CA] font-normal">Design-led. AI-accelerated.</span>
                         </div>
                         {/* Main Heading */}
-                        <h1 className="relative font-extrabold text-3xl sm:text-[52px] md:text-[60px] leading-[1.08] tracking-[-0.03em] text-[#F5F6FA]">
-                            We build businesses on
-                            <br />
-                            <span className="text-[#DC4242]">WordPress</span> &amp;{" "}
+                        <h1 className="relative font-extrabold text-[2rem] leading-[1.12] sm:text-5xl sm:leading-[1.1] lg:text-[52px] xl:text-[58px] tracking-[-0.03em] text-[#F5F6FA]">
+                            We build businesses on{" "}
+                            <span className="text-[#DC4242]">WordPress</span>
+                            <br className="hidden sm:block" /> &amp;{" "}
                             <span className="text-[#DC4242]">Shopify</span>
-                            <span className="ml-1 text-[#DC4242]">.</span>
+                            <span className="text-[#DC4242]">.</span>
                         </h1>
                         {/* Supporting Line */}
-                        <p className="text-[#BCC1CA] mt-4 mb-5 md:mb-12 max-w-xl block text-base lg:text-lg leading-relaxed" style={{maxWidth: '44ch', lineHeight: 1.5}}>
+                        <p className="text-[#BCC1CA] mt-5 mb-6 md:mb-10 text-base lg:text-lg leading-relaxed" style={{maxWidth: '46ch', lineHeight: 1.55}}>
                             Design-led builds — from AI-accelerated prototyping to custom themes, headless storefronts, apps, and integrations that grow your business.
                         </p>
-                        {/* CTAs on one line */}
-                        <div className="flex justify-center lg:justify-start w-full max-w-xs">
-                            <div onClick={e => handleClick(e, "book-call")} className="relative">
-                                <button
-                                    className="flex items-center text-lg whitespace-nowrap group relative shadow-[inset_0_0_0_2px_#616467] text-[#DC4242] px-4 md:px-8 py-2 md:py-4 rounded-full uppercase font-bold bg-transparent hover:bg-[#616467] transition duration-300"
-                                    onMouseEnter={() => setShowTooltip(true)}
-                                    onMouseLeave={() => setShowTooltip(false)}
-                                >
-                                    <span>Book a Free Discovery Call</span>
-                                    <span className="hidden sm:inline-block transition-transform group-hover:translate-x-1 motion-reduce:transform-none ml-2">
-                                        <svg width="20" height="20" fill="none" stroke="currentColor" strokeWidth="2" className="text-[#DC4242]"><path d="M5 12h14M15 8l4 4-4 4"/></svg>
-                                    </span>
-                                </button>
-                                {showTooltip && (
-                                    <span className="absolute left-1/2 -bottom-10 -translate-x-1/2 bg-[#23263a] text-white text-xs px-3 py-2 rounded shadow-lg z-20 whitespace-nowrap animate-fade-in">
-                                        30-minute free strategy session
-                                    </span>
-                                )}
-                            </div>
+                        {/* Primary CTA */}
+                        <div className="relative" onClick={e => handleClick(e, "book-call")}>
+                            <button
+                                className="group inline-flex items-center gap-2 rounded-full bg-[#DC4242] px-7 md:px-8 py-3.5 md:py-4 text-sm md:text-base font-bold uppercase tracking-wide text-white shadow-lg shadow-[#DC4242]/25 transition-all duration-300 hover:bg-[#c23636] hover:shadow-[#DC4242]/40 hover:-translate-y-0.5"
+                                onMouseEnter={() => setShowTooltip(true)}
+                                onMouseLeave={() => setShowTooltip(false)}
+                            >
+                                <span>Book a Free Discovery Call</span>
+                                <svg width="18" height="18" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" className="transition-transform group-hover:translate-x-1 shrink-0"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
+                            </button>
+                            {showTooltip && (
+                                <span className="absolute left-1/2 -bottom-10 -translate-x-1/2 bg-[#23263a] text-white text-xs px-3 py-2 rounded shadow-lg z-20 whitespace-nowrap animate-fade-in">
+                                    30-minute free strategy session
+                                </span>
+                            )}
                         </div>
                     </div>
                     {/* Right Illustration with diagonal divider */}
@@ -123,7 +119,13 @@ export default function Hero() {
                 {/* Client Logo Rail - responsive */}
                 <div className="w-full mt-5 md:mt-14 z-20 flex flex-col gap-6 md:gap-8">
 
-                <div className="overflow-hidden w-full relative before:absolute before:left-0 before:top-0 before:bottom-0 before:w-20 before:bg-gradient-to-r before:from-[#191C26] before:to-transparent before:z-10 after:absolute after:right-0 after:top-0 after:bottom-0 after:w-20 after:bg-gradient-to-l after:from-[#191C26] after:to-transparent after:z-10">
+                <div
+                    className="overflow-hidden w-full"
+                    style={{
+                        maskImage: "linear-gradient(to right, transparent 0, black 7%, black 93%, transparent 100%)",
+                        WebkitMaskImage: "linear-gradient(to right, transparent 0, black 7%, black 93%, transparent 100%)",
+                    }}
+                >
                     {/* Two identical lists; each list carries the same gap as trailing padding so the loop seam is spaced evenly. Track translates exactly -50%. */}
                     <div className="flex animate-logo-rail w-max items-center">
                     {[0, 1].map((listIdx) => (

--- a/app/components/Hero.jsx
+++ b/app/components/Hero.jsx
@@ -65,28 +65,22 @@ export default function Hero() {
                 <div className="relative flex flex-col-reverse lg:flex-row items-center justify-center w-full mx-auto gap-2 lg:gap-20 z-10 px-0">
                     {/* Left Content */}
                     <div className="flex-1 flex flex-col items-center lg:items-start justify-center max-w-2xl text-center lg:text-left max-h-min min-h-10">
-                        {/* Creative Ideas Label (updated copy) */}
+                        {/* Tagline eyebrow */}
                         <div className="flex items-center mb-2 md:mb-6">
                             <span className="block w-12 h-0.5 bg-[#F5F6FA] mr-4" />
-                            <span className="text-base text-[#BCC1CA] font-normal">We&apos;re a small agency which</span>
+                            <span className="text-base text-[#BCC1CA] font-normal">Design-led. AI-accelerated.</span>
                         </div>
                         {/* Main Heading */}
-                        {/* <h1 className="font-extrabold md:mb-2 leading-3 md:leading-tight tracking-wide relative text-[clamp(2.2rem,6vw,3.5rem)] text-[#F5F6FA]">
-                            Bespoke<br className="block" /> Business <br className="hidden sm:block" />
-                            Solutions
-                            <span className="text-[#DC4242] align-super text-5xl ml-1">.</span>
-                        </h1> */}
-                        <h1 className="relative font-extrabold text-3xl sm:text-[56px] md:text-[64px] leading-[1.05] tracking-[-0.03em] text-[#F5F6FA]">
-                            Bespoke
+                        <h1 className="relative font-extrabold text-3xl sm:text-[52px] md:text-[60px] leading-[1.08] tracking-[-0.03em] text-[#F5F6FA]">
+                            We build businesses on
                             <br />
-                            <span className="text-[#DC4242]">Business</span>
-                            <br className="hidden sm:block" />
-                            Solutions
+                            <span className="text-[#DC4242]">WordPress</span> &amp;{" "}
+                            <span className="text-[#DC4242]">Shopify</span>
                             <span className="ml-1 text-[#DC4242]">.</span>
                         </h1>
                         {/* Supporting Line */}
-                        <p className="text-[#BCC1CA] mt-4 mb-5 md:mb-12 max-w-xl block text-base lg:text-lg leading-relaxed" style={{maxWidth: '40ch', lineHeight: 1.5}}>
-                            We create new design for your online business with the support of our wonderful team of professionals.
+                        <p className="text-[#BCC1CA] mt-4 mb-5 md:mb-12 max-w-xl block text-base lg:text-lg leading-relaxed" style={{maxWidth: '44ch', lineHeight: 1.5}}>
+                            Design-led builds — from AI-accelerated prototyping to custom themes, headless storefronts, apps, and integrations that grow your business.
                         </p>
                         {/* CTAs on one line */}
                         <div className="flex justify-center lg:justify-start w-full max-w-xs">
@@ -130,19 +124,21 @@ export default function Hero() {
                 <div className="w-full mt-5 md:mt-14 z-20 flex flex-col gap-6 md:gap-8">
 
                 <div className="overflow-hidden w-full relative before:absolute before:left-0 before:top-0 before:bottom-0 before:w-20 before:bg-gradient-to-r before:from-[#191C26] before:to-transparent before:z-10 after:absolute after:right-0 after:top-0 after:bottom-0 after:w-20 after:bg-gradient-to-l after:from-[#191C26] after:to-transparent after:z-10">
-                    <div className="flex animate-logo-rail whitespace-nowrap w-max gap-12 md:gap-20 items-center" style={{ animation: "logo-rail 18s linear infinite" }}>
-                    {clientLogos.concat(clientLogos).map((logo, idx) => (
-                        <div 
-                            key={idx} 
-                            className="group h-14 md:h-16 px-5 md:px-7 rounded-xl flex items-center justify-center"
-                        >
-                            <Image
-                                src={logo}
-                                alt={`Client Logo ${idx + 1}`}
-                                width={120}
-                                height={48}
-                                className="h-8 md:h-10 w-auto opacity-80 transition-all duration-300 group-hover:opacity-100 group-hover:scale-105"
-                            />
+                    {/* Two identical lists; each list carries the same gap as trailing padding so the loop seam is spaced evenly. Track translates exactly -50%. */}
+                    <div className="flex animate-logo-rail w-max items-center">
+                    {[0, 1].map((listIdx) => (
+                        <div key={listIdx} className="flex items-center shrink-0 gap-14 md:gap-20 pr-14 md:pr-20" aria-hidden={listIdx === 1}>
+                            {clientLogos.map((logo, idx) => (
+                                <div key={idx} className="group h-14 md:h-16 flex items-center justify-center shrink-0">
+                                    <Image
+                                        src={logo}
+                                        alt={`Client Logo ${idx + 1}`}
+                                        width={120}
+                                        height={48}
+                                        className="h-8 md:h-10 w-auto opacity-80 transition-all duration-300 group-hover:opacity-100 group-hover:scale-105"
+                                    />
+                                </div>
+                            ))}
                         </div>
                     ))}
                     </div>
@@ -201,7 +197,7 @@ export default function Hero() {
                 }
                 @keyframes logo-rail {
                     0% { transform: translateX(0); }
-                    100% { transform: translateX(-51%); }
+                    100% { transform: translateX(-50%); }
                 }
                 .animate-logo-rail {
                     animation: logo-rail 18s linear infinite;

--- a/app/components/OurApproachSection.jsx
+++ b/app/components/OurApproachSection.jsx
@@ -13,42 +13,42 @@ export default function OurApproachSection() {
         {
             link: "#",
             image: Empathize,
-            name: "Empathize",
+            name: "Discovery Session",
             zIndex: 40,
-            alt: "Empathize process step icon",
-            description: "Understand user needs, motivations, and pain points through research and observation."
+            alt: "Discovery session process step icon",
+            description: "A focused session to understand your business, current store or site, and what success looks like."
         },
         {
             link: "#",
             image: Define,
-            name: "Define",
+            name: "Scope of Work",
             zIndex: 30,
-            alt: "Define process step icon",
-            description: "Clearly articulate the core problems identified during the empathize phase."
+            alt: "Scope of work process step icon",
+            description: "A clear written scope — deliverables, timeline, and success criteria you can hold us to."
         },
         {
             link: "#",
             image: Ideate,
-            name: "Ideate",
+            name: "Transparent Pricing",
             zIndex: 20,
-            alt: "Ideate process step icon",
-            description: "Brainstorm a wide range of creative solutions and innovative approaches."
+            alt: "Transparent pricing process step icon",
+            description: "Fixed-cost or value-based pricing agreed upfront. No hourly surprises, no scope creep."
         },
         {
             link: "#",
             image: Prototype,
-            name: "Prototype",
+            name: "Build & Delivery",
             zIndex: 10,
-            alt: "Prototype process step icon",
-            description: "Build tangible representations of solutions to test and gather feedback."
+            alt: "Build and delivery process step icon",
+            description: "Design-led build with regular reviews, delivered on the committed timeline."
         },
         {
             link: "#",
             image: Test,
-            name: "Test",
+            name: "Support & Growth",
             zIndex: 0,
-            alt: "Test process step icon",
-            description: "Validate solutions with users, gather insights, and iterate on designs."
+            alt: "Support and growth process step icon",
+            description: "We stay on after launch — support, improvements, and growth as your long-term partner."
         }
     ]
 
@@ -62,9 +62,9 @@ export default function OurApproachSection() {
                             Our Approach
                         </p>
                     </div>
-                    <span className="mt-2 mb-2 lg:mb-0 service-section-heading text-[#FFFFFF]">Right thing matters to us</span>
+                    <span className="mt-2 mb-2 lg:mb-0 service-section-heading text-[#FFFFFF]">From discovery to delivery</span>
                     <span className="text-sm sm:text-base text-[#BCC1CA]/80 mt-2 max-w-2xl leading-relaxed">
-                        Our process ensures we deliver the right solutions, every time. Here&apos;s how we work with you.
+                        A clear engagement process — you know the scope, the price, and the timeline before we write a line of code.
                     </span>
                 </div>
 

--- a/app/components/OurServicesSection.jsx
+++ b/app/components/OurServicesSection.jsx
@@ -28,7 +28,7 @@ const services = [
     image: "/DesignSystem.png",
     title: "Design & Prototyping",
     bullets: [
-      { txt: "Wireframing & mockups", tip: "Low → high fidelity screens that map every interaction." },
+      { txt: "AI-accelerated wireframes & mockups", tip: "AI-assisted design moves from idea to high-fidelity screens in days, not weeks." },
       { txt: "Design systems & branding", tip: "Re-usable components that ensure brand consistency at scale." },
       { txt: "Interactive prototypes", tip: "Clickable demos for rapid feedback before writing code." },
       { txt: "User testing", tip: "Task-based sessions to refine UX and boost conversion." },
@@ -59,12 +59,12 @@ const services = [
 
   {
     image: "/Prototyping.png",
-    title: "Custom Web Development",
+    title: "Integrations & Automation",
     bullets: [
-      { txt: "Custom website development", tip: "Bespoke sites tailored to your brand and goals." },
-      { txt: "Full-stack web applications", tip: "React, Next.js, Node and modern backend architectures." },
-      { txt: "Scalable web solutions", tip: "Architecture and ops that grow with your product." },
-      { txt: "API development & integrations", tip: "Robust APIs and third-party integrations for data flow." },
+      { txt: "API & CRM integrations", tip: "Connect your store or site to CRMs, email, and business systems." },
+      { txt: "Workflow & AI automation", tip: "Automate order flows, notifications, and back-office busywork." },
+      { txt: "Payments, shipping & ERP", tip: "Reliable hookups to the platforms your operations run on." },
+      { txt: "Custom web apps when needed", tip: "Bespoke full-stack development as the supporting layer for automations and integrations." },
     ],
   },
 ];

--- a/app/components/OurTeamSection.jsx
+++ b/app/components/OurTeamSection.jsx
@@ -44,33 +44,7 @@ const team = [
     tone: "from-[#2E2617]/80 to-[#0F1118]",
     accent: "#FFC857",
   },
-  {
-    image: "/Manish_Rana.png",
-    name: "Manish Rana",
-    role: "UX/UI Expert",
-    bio: "Shapes intuitive user experiences and scalable design systems that balance aesthetics, usability, and conversion across digital products.",
-    hue: "from-[#5A6BFF]/80 via-[#343B6F]/60 to-[#191C26]/80",
-    quote: "Good design feels invisible—until it starts driving results.",
-    tone: "from-[#202435]/80 to-[#0F1118]",
-    accent: "#5A6BFF",
-  },
-  {
-    image: "/Divy.jpg",
-    name: "Divyansh Veermanya",
-    role: "Product Lead",
-    bio: "Owns product vision and execution by translating business goals and user insights into clear roadmaps, priorities, and shipped outcomes.",
-    hue: "from-[#6B8CFF]/80 via-[#2E356B]/60 to-[#191C26]/80",
-    quote: "Great products are built by aligning teams around the right problems.",
-    tone: "from-[#1B2140]/80 to-[#0F1118]",
-    accent: "#6B8CFF",
-  },
 ];
-
-const moreMembersCard = {
-  isSpecial: true,
-  name: "More members",
-  count: "+3"
-};
 
 export default function OurTeamSection() {
   const swiperRef = useRef(null);
@@ -90,20 +64,18 @@ export default function OurTeamSection() {
     return () => window.removeEventListener('resize', updateBreakpoint);
   }, []);
 
-  // Mobile: 6 slides with 1 item each (individual slides)
-  const mobileSlides = [...team, moreMembersCard];
+  // Mobile: one slide per member
+  const mobileSlides = [...team];
 
-  // Tablet: 3 slides with 2 items each
+  // Tablet: 2 slides (2 + 1)
   const tabletSlideGroups = [
     team.slice(0, 2),
-    team.slice(2, 4),
-    [...team.slice(4, 5), moreMembersCard]
+    team.slice(2, 3)
   ];
 
-  // Desktop: 2 slides with 3 items each (current structure)
+  // Desktop: all three on one slide
   const desktopSlideGroups = [
-    team.slice(0, 3),
-    [...team.slice(3, 5), moreMembersCard]
+    team.slice(0, 3)
   ];
 
   // Determine which slide groups to use and calculate maxIndex
@@ -165,28 +137,6 @@ export default function OurTeamSection() {
     </article>
   );
 
-  // Helper function to render the special "More members" card
-  const renderMoreMembersCard = (member, key) => (
-    <article
-      key={key}
-      className="relative min-h-[380px] min-w-[200px] shrink-0 transition-transform duration-500 sm:min-w-xs md:min-w-[285px]"
-    >
-      <div className="flex min-h-[380px] items-center justify-center rounded-[28px] border border-dashed border-white/15 bg-[linear-gradient(135deg,rgba(255,255,255,0.06),rgba(7,9,14,0.95))] px-6 py-8 text-center shadow-[0_20px_70px_rgba(0,0,0,0.25)] backdrop-blur-xl">
-        <div>
-          <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-full border border-white/10 bg-white/5 text-2xl font-semibold text-[#F5F6FA]">
-            +
-          </div>
-          <p className="mt-5 text-4xl font-semibold text-[#F5F6FA]">
-            {member.count}
-          </p>
-          <p className="mt-2 text-sm uppercase tracking-[0.25em] text-[#BCC1CA]">
-            {member.name}
-          </p>
-        </div>
-      </div>
-    </article>
-  );
-
   return (
     <section
       id="about"
@@ -214,14 +164,14 @@ export default function OurTeamSection() {
             The minds behind your growth
           </span>
           <span className="text-sm sm:text-base text-[#BCC1CA]/80 mt-2 max-w-2xl leading-relaxed">
-            A multidisciplinary team blending strategy, design, engineering, and growth.
-            We move fast, align to outcomes, and keep collaboration transparent.
+            A small senior team — strategy, engineering, and Shopify expertise working
+            directly with you. No layers, no hand-offs.
           </span>
         </div>
         {/* Carousel */}
         <div className="relative py-10 md:py-0">
-          {/* Controls */}
-          <div className="mb-5 hidden lg:flex items-center justify-between">
+          {/* Controls (hidden when everything fits on one slide) */}
+          <div className={`mb-5 items-center justify-between ${maxIndex > 0 ? "hidden lg:flex" : "hidden"}`}>
             <div></div>
             <div className="flex items-center gap-3">
               <div className="flex gap-2">
@@ -273,12 +223,10 @@ export default function OurTeamSection() {
           >
             {isMobile ? (
               // Mobile: Individual slides (1 item per slide)
-              mobileSlides.map((member, index) => (
-                <SwiperSlide key={member.isSpecial ? `more-${index}` : member.name}>
+              mobileSlides.map((member) => (
+                <SwiperSlide key={member.name}>
                   <div className="flex justify-center items-stretch">
-                    {member.isSpecial
-                      ? renderMoreMembersCard(member, `more-${index}`)
-                      : renderTeamMemberCard(member, member.name)}
+                    {renderTeamMemberCard(member, member.name)}
                   </div>
                 </SwiperSlide>
               ))
@@ -287,19 +235,15 @@ export default function OurTeamSection() {
               slideGroups.map((group, groupIndex) => (
                 <SwiperSlide key={groupIndex}>
                   <div className="flex gap-1 md:gap-6 justify-center items-stretch p-0">
-                    {group.map((member, idx) =>
-                      member.isSpecial
-                        ? renderMoreMembersCard(member, `more-${groupIndex}-${idx}`)
-                        : renderTeamMemberCard(member, member.name)
-                    )}
+                    {group.map((member) => renderTeamMemberCard(member, member.name))}
             </div>
             </SwiperSlide>
               ))
             )}
           </Swiper>
 
-          {/* Dots Indicator */}
-          <div className="mt-8 flex justify-center">
+          {/* Dots Indicator (hidden when there is only one slide) */}
+          <div className={`mt-8 justify-center ${maxIndex > 0 ? "flex" : "hidden"}`}>
             <div className="flex gap-2">
               {Array.from({ length: maxIndex + 1 }).map((_, i) => (
                 <button

--- a/app/components/OurTeamSection.jsx
+++ b/app/components/OurTeamSection.jsx
@@ -1,17 +1,7 @@
 "use client";
 
 import Image from "next/image";
-import React, { useRef, useState, useEffect, useMemo } from "react";
-import { SwiperSlide } from 'swiper/react';
-import { Navigation } from 'swiper/modules';
-import 'swiper/css';
-import 'swiper/css/navigation';
-import dynamic from "next/dynamic";
-
-const Swiper = dynamic(
-    () => import("swiper/react").then((mod) => mod.Swiper),
-    { ssr: false }
-);
+import React from "react";
 
 const team = [
   {
@@ -47,46 +37,11 @@ const team = [
 ];
 
 export default function OurTeamSection() {
-  const swiperRef = useRef(null);
-  const [activeIndex, setActiveIndex] = useState(0);
-  const [isMobile, setIsMobile] = useState(false);
-  const [isTablet, setIsTablet] = useState(false);
-
-  useEffect(() => {
-    const updateBreakpoint = () => {
-      const width = window.innerWidth;
-      setIsMobile(width < 880);
-      setIsTablet(width >= 880 && width < 1280);
-    };
-
-    updateBreakpoint();
-    window.addEventListener('resize', updateBreakpoint);
-    return () => window.removeEventListener('resize', updateBreakpoint);
-  }, []);
-
-  // Mobile: one slide per member
-  const mobileSlides = [...team];
-
-  // Tablet: 2 slides (2 + 1)
-  const tabletSlideGroups = [
-    team.slice(0, 2),
-    team.slice(2, 3)
-  ];
-
-  // Desktop: all three on one slide
-  const desktopSlideGroups = [
-    team.slice(0, 3)
-  ];
-
-  // Determine which slide groups to use and calculate maxIndex
-  const slideGroups = isMobile ? mobileSlides : (isTablet ? tabletSlideGroups : desktopSlideGroups);
-  const maxIndex = Math.max(0, slideGroups.length - 1);
-
   // Helper function to render a team member card
   const renderTeamMemberCard = (member, key) => (
     <article
       key={key}
-      className="group relative mx-auto w-full min-h-[380px] max-w-[300px] shrink-0 transition-all duration-500 sm:max-w-xs md:max-w-[360px]"
+      className="group relative w-full min-h-[380px] transition-all duration-500"
     >
       <div className="relative flex h-full flex-col overflow-hidden rounded-[28px] border border-white/10 bg-[linear-gradient(135deg,rgba(255,255,255,0.06),rgba(10,12,18,0.96))] p-5 shadow-[0_20px_70px_rgba(0,0,0,0.28)] backdrop-blur-xl transition-all duration-500 hover:-translate-y-1 hover:border-white/20 hover:shadow-[0_24px_80px_rgba(0,0,0,0.32)] xs:p-6">
         <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(255,255,255,0.08),transparent_45%)] opacity-70" />
@@ -168,97 +123,9 @@ export default function OurTeamSection() {
             directly with you. No layers, no hand-offs.
           </span>
         </div>
-        {/* Carousel */}
-        <div className="relative py-10 md:py-0">
-          {/* Controls (hidden when everything fits on one slide) */}
-          <div className={`mb-5 items-center justify-between ${maxIndex > 0 ? "hidden lg:flex" : "hidden"}`}>
-            <div></div>
-            <div className="flex items-center gap-3">
-              <div className="flex gap-2">
-                <button
-                  aria-label="Previous"
-                  onClick={() => swiperRef.current?.slidePrev()}
-                  className="group flex h-12 w-12 items-center justify-center rounded-full border border-[#343844] bg-gradient-to-br from-[#0F1118] to-[#131623] text-[#F5F6FA] transition-all hover:border-[#DC4242] hover:scale-105 disabled:opacity-50 disabled:cursor-not-allowed"
-                >
-                  <svg className="w-5 h-5 transition-transform group-hover:-translate-x-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
-                  </svg>
-                </button>
-                <button
-                  aria-label="Next"
-                  onClick={() => swiperRef.current?.slideNext()}
-                  className="group flex h-12 w-12 items-center justify-center rounded-full border border-[#343844] bg-gradient-to-br from-[#0F1118] to-[#131623] text-[#F5F6FA] transition-all hover:border-[#DC4242] hover:scale-105 disabled:opacity-50 disabled:cursor-not-allowed"
-                >
-                  <svg className="w-5 h-5 transition-transform group-hover:translate-x-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-                  </svg>
-                </button>
-              </div>
-            </div>
-          </div>
-
-          {/* Carousel Container */}
-          <Swiper
-            onSwiper={(swiper) => {
-              swiperRef.current = swiper;
-            }}
-            onSlideChange={(swiper) => {
-              setActiveIndex(swiper.activeIndex);
-            }}
-            spaceBetween={10}
-            slidesPerView={1.1}
-            breakpoints={{
-              880: {
-                slidesPerView: 1,
-                spaceBetween: 24,
-              },
-              1280: {
-                slidesPerView: 1,
-                spaceBetween: 30,
-              },
-            }}
-            grabCursor={true}
-            modules={[Navigation]}
-            className="relative overflow-visible"
-          >
-            {isMobile ? (
-              // Mobile: Individual slides (1 item per slide)
-              mobileSlides.map((member) => (
-                <SwiperSlide key={member.name}>
-                  <div className="flex justify-center items-stretch">
-                    {renderTeamMemberCard(member, member.name)}
-                  </div>
-                </SwiperSlide>
-              ))
-            ) : (
-              // Tablet & Desktop: Grouped slides (multiple items per slide)
-              slideGroups.map((group, groupIndex) => (
-                <SwiperSlide key={groupIndex}>
-                  <div className="flex gap-1 md:gap-6 justify-center items-stretch p-0">
-                    {group.map((member) => renderTeamMemberCard(member, member.name))}
-            </div>
-            </SwiperSlide>
-              ))
-            )}
-          </Swiper>
-
-          {/* Dots Indicator (hidden when there is only one slide) */}
-          <div className={`mt-8 justify-center ${maxIndex > 0 ? "flex" : "hidden"}`}>
-            <div className="flex gap-2">
-              {Array.from({ length: maxIndex + 1 }).map((_, i) => (
-                <button
-                  key={i}
-                  onClick={() => swiperRef.current?.slideTo(i)}
-                  className={`h-1.5 rounded-full transition-all duration-500 ${
-                    i === activeIndex
-                      ? "w-8 bg-gradient-to-r from-[#DC4242] to-[#5A6BFF]"
-                      : "w-1.5 bg-[#343844] hover:bg-[#5A6BFF]/50"
-                  }`}
-                  aria-label={`Go to slide ${i + 1}`}
-                />
-              ))}
-            </div>
-          </div>
+        {/* Team grid — three members, no carousel needed */}
+        <div className="mt-10 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5 md:gap-6 items-stretch">
+          {team.map((member) => renderTeamMemberCard(member, member.name))}
         </div>
       </div>
     </section>

--- a/app/page.jsx
+++ b/app/page.jsx
@@ -1,5 +1,6 @@
 import Footer from "./components/Footer";
 import Hero from "./components/Hero";
+import FeaturedCaseStudy from "./components/FeaturedCaseStudy";
 import OurServicesSection from "./components/OurServicesSection";
 // import IndustriesSection from "./components/IndustriesSection";
 import OurApproachSection from "./components/OurApproachSection";
@@ -11,6 +12,7 @@ export default function Home() {
   return (
     <main className="bg-[#191C26] overflow-x-hidden sm:pt-[60px]">
       <Hero />
+      <FeaturedCaseStudy />
       <OurServicesSection />
       {/* <IndustriesSection /> */}
       <OurApproachSection />

--- a/app/shopify-development/components/ShopifyTechStack.jsx
+++ b/app/shopify-development/components/ShopifyTechStack.jsx
@@ -7,18 +7,19 @@ import {
   SiGraphql,
 } from "react-icons/si";
 import { FiDroplet, FiCpu, FiMail } from "react-icons/fi";
-import { RiStarSFill } from "react-icons/ri";
+import { RiVipCrownFill } from "react-icons/ri";
 
 export default function ShopifyTechStack() {
+  // Each logo keeps its real brand color so it reads as a recognizable mark.
   const techs = [
-    { icon: <SiShopify className="w-5 h-5" />, name: "Shopify", desc: "Core Platform" },
-    { icon: <RiStarSFill className="w-5 h-5" />, name: "Shopify Plus", desc: "Enterprise Commerce" },
-    { icon: <FiDroplet className="w-5 h-5" />, name: "Liquid", desc: "Template Language" },
-    { icon: <FiCpu className="w-5 h-5" />, name: "Hydrogen", desc: "Headless Framework" },
-    { icon: <SiReact className="w-5 h-5" />, name: "React", desc: "Storefront UI" },
-    { icon: <SiNextdotjs className="w-5 h-5" />, name: "Next.js", desc: "Commerce Framework" },
-    { icon: <SiGraphql className="w-5 h-5" />, name: "GraphQL", desc: "Storefront API" },
-    { icon: <FiMail className="w-5 h-5" />, name: "Klaviyo", desc: "Email Automation" },
+    { icon: <SiShopify className="w-6 h-6" />, color: "#95BF47", name: "Shopify", desc: "Core Platform" },
+    { icon: <RiVipCrownFill className="w-6 h-6" />, color: "#C9A227", name: "Shopify Plus", desc: "Enterprise Commerce" },
+    { icon: <FiDroplet className="w-6 h-6" />, color: "#7AB55C", name: "Liquid", desc: "Template Language" },
+    { icon: <FiCpu className="w-6 h-6" />, color: "#5BB98B", name: "Hydrogen", desc: "Headless Framework" },
+    { icon: <SiReact className="w-6 h-6" />, color: "#61DAFB", name: "React", desc: "Storefront UI" },
+    { icon: <SiNextdotjs className="w-6 h-6" />, color: "#FFFFFF", name: "Next.js", desc: "Commerce Framework" },
+    { icon: <SiGraphql className="w-6 h-6" />, color: "#E10098", name: "GraphQL", desc: "Storefront API" },
+    { icon: <FiMail className="w-6 h-6" />, color: "#F5A623", name: "Klaviyo", desc: "Email Automation" },
   ];
 
   const loopedTechs = [...techs, ...techs];
@@ -50,7 +51,10 @@ export default function ShopifyTechStack() {
                 key={`${tech.name}-${idx}`}
                 className="group min-w-[170px] sm:min-w-[190px] rounded-xl border border-[#2a2e40]/70 bg-[#181B23]/90 px-4 py-4 sm:px-5 sm:py-5 text-center shadow-sm transition-all duration-300 hover:border-[#DC4242]/40 hover:bg-[#1E222D]"
               >
-                <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-lg border border-[#2a2e40] bg-[#191C26] text-[#BCC1CA] transition-all duration-300 group-hover:border-[#DC4242]/30 group-hover:text-[#DC4242]">
+                <div
+                  className="mb-3 mx-auto flex h-11 w-11 items-center justify-center rounded-xl border border-[#2a2e40] bg-[#0F1118] transition-all duration-300 group-hover:border-[#DC4242]/30"
+                  style={{ color: tech.color }}
+                >
                   {tech.icon}
                 </div>
                 <h4 className="mb-1 text-sm font-semibold text-white transition-colors duration-300 group-hover:text-[#DC4242]">

--- a/app/shopify-development/components/ShopifyTrust.jsx
+++ b/app/shopify-development/components/ShopifyTrust.jsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { FiZap, FiLock, FiTrendingUp, FiEdit2 } from "react-icons/fi";
+import { FaShopify } from "react-icons/fa";
 
 export default function ShopifyTrust() {
   const advantages = [
@@ -44,6 +45,16 @@ export default function ShopifyTrust() {
           <p className="softles-section-copy mx-auto">
             Shopify powers over 4.6 million stores worldwide. It&apos;s the platform built to convert browsers into buyers — and to scale without friction.
           </p>
+
+          {/* Partner framing — we build with Shopify, as partners, not resellers */}
+          <div className="flex justify-center mt-6">
+            <div className="inline-flex items-center gap-2.5 rounded-full border border-[#95BF47]/30 bg-[#95BF47]/[0.07] px-5 py-2.5">
+              <FaShopify className="w-5 h-5 text-[#95BF47] shrink-0" />
+              <span className="text-sm text-[#BCC1CA]">
+                <span className="font-bold text-white">SoftLes × Shopify</span> — we work as a Shopify partner agency, building on the platform every day.
+              </span>
+            </div>
+          </div>
         </div>
 
         {/* Unified Cards Grid */}


### PR DESCRIPTION
Implements the stakeholder notes for the homepage (and one Shopify-page tweak).

## Changes
**Hero** — new positioning *"We build businesses on WordPress & Shopify"* + "Design-led. AI-accelerated." tagline. Fixed uneven **logo-rail spacing** on the marquee (even gap + seamless loop).

**Featured case study** — single strong story (Brunswick Fur Food, with stats + live-store link) under the hero instead of a wall of logos.

**Services** — reframed around *what we do*: AI-led Design & Prototyping, Shopify dev, WordPress dev, and **Integrations & Automation** (Custom Web Dev folded in here as a supporting layer, not a primary offering).

**Approach** — reframed as the real engagement process: **Discovery Session → Scope of Work → Transparent Pricing → Build & Delivery → Support & Growth**.

**Team** — honest **team of three** (Shakti, Shahad, Neeraj). Removed the fake "+3 more members" card and the "multidisciplinary team" inflation; carousel controls/dots hide when everything fits.

**Contact** — replaced the booking form + Google Meet card with a **WhatsApp-first** section: name + WhatsApp number → opens WhatsApp with a prefilled message (lead still captured via EmailJS in the background). Phone + email shown.

**Footer** — added **WordPress** and **Shopify** service-link columns (lead-gen) + a **Resources** column (blog). Removed the newsletter block.

**Shopify page** — added a **"SoftLes × Shopify"** partner-framing pill (partner tone, not bragging).

## Verification
- `npm run build` passes; all routes compile ✅
- Rendered locally — hero, case study, services, approach steps, 3-person team, WhatsApp contact, and footer all confirmed ✅

## Deferred (per notes)
Products page (library-management software / Webflow solutions) — future. Newsletter — maybe later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)