### PR TITLE
Fix WordPress work mockups + route LP form through Resend

### DIFF
--- a/app/api/contact/route.js
+++ b/app/api/contact/route.js
@@ -10,11 +10,18 @@ export async function POST(request) {
 
   const name = (body.name || "").trim();
   const email = (body.email || "").trim();
-  const phone = (body.phone || "").trim();
+  const phone = (body.phone || body.whatsapp || "").trim();
   const message = (body.message || "").trim();
+  const storeUrl = (body.storeUrl || "").trim();
+  const goal = (body.goal || "").trim();
+  const source = (body.source || "Website contact form").trim();
 
-  if (!name || !email) {
-    return Response.json({ error: "Name and email are required." }, { status: 400 });
+  // Need a name and at least one way to reply.
+  if (!name || (!email && !phone)) {
+    return Response.json(
+      { error: "Name and an email or phone number are required." },
+      { status: 400 }
+    );
   }
 
   const apiKey = process.env.RESEND_API_KEY;
@@ -25,27 +32,40 @@ export async function POST(request) {
 
   const resend = new Resend(apiKey);
   const to = process.env.CONTACT_TO_EMAIL || "softlesweb@gmail.com";
-  // Switch to a verified domain sender (e.g. "SoftLes <hello@softles.in>") once softles.in is verified in Resend.
   const from = process.env.CONTACT_FROM_EMAIL || "SoftLes Website <onboarding@resend.dev>";
 
+  const rows = [
+    ["Name", name],
+    ["Email", email || "—"],
+    ["Phone / WhatsApp", phone || "—"],
+    goal ? ["Goal", goal] : null,
+    storeUrl ? ["Store / site URL", storeUrl] : null,
+    ["Source", source],
+  ].filter(Boolean);
+
   const html = `
-    <h2 style="margin:0 0 12px">New enquiry from softles.in</h2>
-    <p><strong>Name:</strong> ${escapeHtml(name)}</p>
-    <p><strong>Email:</strong> ${escapeHtml(email)}</p>
-    <p><strong>Phone / WhatsApp:</strong> ${escapeHtml(phone || "—")}</p>
-    <p><strong>Message:</strong></p>
-    <p style="white-space:pre-wrap">${escapeHtml(message || "(no message)")}</p>
+    <h2 style="margin:0 0 12px">New lead — ${escapeHtml(source)}</h2>
+    <table style="border-collapse:collapse;font-family:sans-serif;font-size:14px">
+      ${rows
+        .map(
+          ([k, v]) =>
+            `<tr><td style="padding:4px 12px 4px 0;color:#666"><strong>${escapeHtml(k)}</strong></td><td style="padding:4px 0">${escapeHtml(v)}</td></tr>`
+        )
+        .join("")}
+    </table>
+    ${message ? `<p style="margin-top:16px"><strong>Message:</strong></p><p style="white-space:pre-wrap;font-family:sans-serif;font-size:14px">${escapeHtml(message)}</p>` : ""}
   `;
 
   try {
-    const { data, error } = await resend.emails.send({
+    const payload = {
       from,
       to: [to],
-      replyTo: email,
-      subject: `New enquiry from ${name}`,
+      subject: `New lead — ${source}: ${name}`,
       html,
-    });
+    };
+    if (email) payload.replyTo = email;
 
+    const { data, error } = await resend.emails.send(payload);
     if (error) {
       console.error("Resend error:", error);
       return Response.json({ error: error.message || "Failed to send." }, { status: 502 });

--- a/app/components/_components/WordPressProjectShowcase.jsx
+++ b/app/components/_components/WordPressProjectShowcase.jsx
@@ -1,31 +1,46 @@
 "use client";
 
-import Image from "next/image";
 import Link from "next/link";
 import { useEffect, useRef, useState } from "react";
 import { Swiper, SwiperSlide } from "swiper/react";
 import { Autoplay } from "swiper/modules";
 import "swiper/css";
 
-function ProjectImage({ project }) {
-  if (project.image) {
-    return (
-      <Image
-        src={project.image}
-        alt={`${project.title} website`}
-        fill
-        className="object-cover object-top"
-        sizes="(max-width: 1024px) 100vw, 50vw"
-      />
-    );
-  }
+function BrowserPreview({ project }) {
+  const domain = project.url
+    ? project.url.replace(/^https?:\/\//, "").replace(/\/$/, "")
+    : project.title;
 
   return (
-    <div className="absolute inset-0 flex flex-col items-center justify-center bg-gradient-to-br from-[#161C27] via-[#1a1e2a] to-[#23263a] p-8 text-center">
-      <div className="w-16 h-16 sm:w-20 sm:h-20 rounded-full border-2 border-[rgba(255,77,87,0.4)] bg-[rgba(255,77,87,0.1)] flex items-center justify-center text-2xl sm:text-3xl mb-3">
-        {project.placeholderIcon || "▶️"}
+    <div className="flex h-full flex-col bg-[#0E1219]">
+      {/* Browser chrome */}
+      <div className="flex items-center gap-2 px-3 sm:px-4 py-2.5 bg-[#161C27] border-b border-[#2E3446] shrink-0">
+        <span className="flex gap-1.5">
+          <span className="h-2.5 w-2.5 rounded-full bg-[#FF5F57]" />
+          <span className="h-2.5 w-2.5 rounded-full bg-[#FEBC2E]" />
+          <span className="h-2.5 w-2.5 rounded-full bg-[#28C840]" />
+        </span>
+        <span className="ml-1 flex-1 truncate rounded-md bg-[#0E1219] border border-[#2E3446] px-3 py-1 text-[11px] text-[#C7CCD6]/70">
+          {domain}
+        </span>
       </div>
-      <p className="text-[#FFFFFF] font-bold text-lg sm:text-xl">{project.title}</p>
+
+      {/* Screenshot viewport — shows the top of the site in a browser window */}
+      <div className="group/preview relative flex-1 min-h-[240px] sm:min-h-[300px] w-full overflow-hidden">
+        {project.image ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={project.image}
+            alt={`${project.title} website`}
+            loading="lazy"
+            className="absolute inset-0 h-full w-full object-cover object-top transition-transform duration-[600ms] ease-out group-hover/preview:scale-[1.03]"
+          />
+        ) : (
+          <div className="absolute inset-0 flex flex-col items-center justify-center p-8 text-center">
+            <p className="text-[#FFFFFF] font-bold text-lg sm:text-xl">{project.title}</p>
+          </div>
+        )}
+      </div>
     </div>
   );
 }
@@ -38,15 +53,15 @@ function ProjectSlide({ project, isActive }) {
       }`}
     >
       <div className="grid grid-cols-1 md:grid-cols-2">
-        <div className="relative min-h-[200px] sm:min-h-[260px] md:min-h-[320px] bg-[#161C27] border-b md:border-b-0 md:border-r border-[#2E3446]">
-          <ProjectImage project={project} />
-          <div className="absolute top-4 left-4 z-[2]">
+        <div className="relative overflow-hidden border-b md:border-b-0 md:border-r border-[#2E3446]">
+          <BrowserPreview project={project} />
+          <div className="absolute top-[54px] left-4 z-[2]">
             <span className="inline-flex rounded-full border border-white/10 bg-[#0E1219]/85 backdrop-blur-md px-3 py-1 text-[10px] sm:text-xs font-semibold uppercase tracking-widest text-[#F5F6FA]">
               {project.industry}
             </span>
           </div>
           {project.badge && (
-            <div className="absolute top-4 right-4 z-[2]">
+            <div className="absolute top-[54px] right-4 z-[2]">
               <span className="inline-flex rounded-full bg-[rgba(255,77,87,0.15)] border border-[rgba(255,77,87,0.3)] px-3 py-1 text-[10px] sm:text-xs font-semibold text-[#FF4D57]">
                 {project.badge}
               </span>

--- a/app/lp/shopify/components/LeadForm.jsx
+++ b/app/lp/shopify/components/LeadForm.jsx
@@ -1,13 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import emailjs from "@emailjs/browser";
 import { trackPixel } from "@/lib/metaPixel";
-
-// Reuses the site's existing EmailJS credentials.
-const EMAILJS_SERVICE = "service_db4zwz8";
-const EMAILJS_TEMPLATE = "template_oiu2ped";
-const EMAILJS_PUBLIC_KEY = "oo80cgXuN0GQTNqFm";
 
 const GOALS = [
   "Redesign my store",
@@ -25,33 +19,30 @@ export default function LeadForm({ ctaLabel = "Talk to a Shopify Expert" }) {
 
   const valid = name.trim() && whatsapp.trim();
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
     if (!valid || status === "loading") return;
     setStatus("loading");
 
-    emailjs
-      .send(
-        EMAILJS_SERVICE,
-        EMAILJS_TEMPLATE,
-        {
-          user_name: name,
-          user_phone: whatsapp,
-          user_email: "",
-          user_message: `New Shopify landing-page lead\nWhatsApp: ${whatsapp}\nStore URL: ${
-            storeUrl || "—"
-          }\nGoal: ${goal}\nSource: Meta Ads — /lp/shopify`,
-        },
-        EMAILJS_PUBLIC_KEY
-      )
-      .then(() => {
-        setStatus("sent");
-        trackPixel("Lead", { content_name: "shopify-lp", goal });
-      })
-      .catch((err) => {
-        console.error(err);
-        setStatus("error");
+    try {
+      const res = await fetch("/api/contact", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name,
+          phone: whatsapp,
+          storeUrl,
+          goal,
+          source: "Shopify Landing Page (/lp/shopify)",
+        }),
       });
+      if (!res.ok) throw new Error("Request failed");
+      setStatus("sent");
+      trackPixel("Lead", { content_name: "shopify-lp", goal });
+    } catch (err) {
+      console.error(err);
+      setStatus("error");
+    }
   };
 
   if (status === "sent") {


### PR DESCRIPTION
- WordPress project showcase now uses browser-window frames so the site mockups display properly (was a cropped strip)
- Generalized /api/contact (email or phone) with a source tag
- Shopify LP lead form switched from the broken EmailJS to Resend (leads were silently failing), keeps the Meta Pixel Lead event

🤖 Generated with [Claude Code](https://claude.com/claude-code)